### PR TITLE
Put Apache2-required copyright definitions back

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2017 The Linux Foundation
 # Copyright (C) 2017 The halogenOS Project
+# Modifications Copyright (C) 2017 The Halium Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2017 The Linux Foundation
-# Copyright (C) 2017 The Halium Project
+# Copyright (C) 2017 The halogenOS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/device.mk
+++ b/device.mk
@@ -1,6 +1,7 @@
 #
 # Copyright (C) 2017 The Linux Foundation
 # Copyright (C) 2017 The halogenOS Project
+# Modifications Copyright (C) 2017 The Halium Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/device.mk
+++ b/device.mk
@@ -1,6 +1,6 @@
 #
 # Copyright (C) 2017 The Linux Foundation
-# Copyright (C) 2017 The Halium Project
+# Copyright (C) 2017 The halogenOS Project
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Yes, I know, I'm being *that guy*.

The Apache License 2.0 requires that all copyright definitions on a file are kept intact.

[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0.html), section 4c